### PR TITLE
CRITICAL HOTFIX: Fix infinite loading loop

### DIFF
--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -19,7 +19,7 @@ import {
   Square,
 } from "lucide-react";
 import type { FC } from "react";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 
 import {
   ComposerAddAttachment,
@@ -39,14 +39,14 @@ import { type WelcomeMessage, type ChatConfig } from "@/lib/api/schemas/chat";
 export const Thread: FC = () => {
   const [chatConfig, setChatConfig] = useState<ChatConfig | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [hasFetched, setHasFetched] = useState(false);
+  const hasFetchedRef = useRef(false);
 
   useEffect(() => {
     // Prevent duplicate fetches
-    if (hasFetched) return;
+    if (hasFetchedRef.current) return;
+    hasFetchedRef.current = true;
 
     let isCancelled = false;
-    setHasFetched(true);
 
     getChatConfig()
       .then((config) => {
@@ -88,7 +88,7 @@ export const Thread: FC = () => {
     return () => {
       isCancelled = true;
     };
-  }, [hasFetched]);
+  }, []); // Empty dependency - only run once on mount
 
   return (
     <div className="relative h-full">


### PR DESCRIPTION
CRITICAL HOTFIX: Fix infinite loading loop

Site was stuck in infinite loading due to useState causing re-render loops in chat API integration.

**Fix:** Changed hasFetched from useState to useRef to break the re-render cycle.

This resolves the critical production deployment issue preventing site access.