### PR TITLE
feat(debug): add viewport debug overlay for mobile testing

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-'use client'
+"use client";
 import { Scene } from "@/components/Scene";
 import { LoadingScene } from "@/components/LoadingScene";
 import { Footer } from "@/components/footer/Footer";
@@ -6,12 +6,14 @@ import { ExtensionWarning } from "@/components/ExtensionWarning";
 import { Scene3DErrorBoundary } from "@/components/scene/Scene3DErrorBoundary";
 import { useAtomValue } from "jotai";
 import { isLoadedAtom } from "@/atoms/atomStore";
+import { DebugViewport } from "@/components/DebugViewport";
 
 export default function Home() {
   const isLoaded = useAtomValue(isLoadedAtom);
 
   return (
     <div className="h-[100dvh] w-full flex flex-col items-center justify-center">
+      <DebugViewport />
       <ExtensionWarning />
       {!isLoaded && <LoadingScene />}
       <Scene3DErrorBoundary>

--- a/src/components/DebugViewport.tsx
+++ b/src/components/DebugViewport.tsx
@@ -1,0 +1,42 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export function DebugViewport() {
+  const [info, setInfo] = useState<any>(null);
+
+  useEffect(() => {
+    setInfo({
+      width: window.innerWidth,
+      height: window.innerHeight,
+      dpr: window.devicePixelRatio,
+      isMobile: /Android|iPhone/i.test(navigator.userAgent),
+    });
+  }, []);
+
+  if (!info) return null;
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        background: "rgba(0,0,0,0.9)",
+        color: "#00ff00",
+        padding: "15px",
+        fontSize: "16px",
+        zIndex: 9999,
+        fontFamily: "monospace",
+        borderRadius: "0 0 8px 0",
+      }}
+    >
+      <div>Width: {info.width}px</div>
+      <div>Height: {info.height}px</div>
+      <div>DPR: {info.dpr}</div>
+      <div>Mobile: {info.isMobile ? "YES" : "NO"}</div>
+      <div style={{ marginTop: "8px", fontSize: "12px", color: "#888" }}>
+        {info.width < 500 ? "✓ Viewport working" : "✗ Viewport NOT working"}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Add temporary debug overlay to verify viewport meta configuration is working correctly on high-DPI mobile devices like the Galaxy S24 Ultra (3120×1440). Displays viewport dimensions, device pixel ratio, and configuration status directly on-screen without requiring Chrome DevTools access.

## Changes

- Create `DebugViewport` component displaying width, height, DPR, and mobile detection status
- Add visual indicator (✓/✗) showing if viewport configuration is working
- Render as fixed green overlay in top-left corner for easy visibility
- Add to page.tsx for immediate testing

## Type of Change

- [x] New feature (diagnostic/debugging tool)
- [ ] Bug fix
- [ ] Code quality improvement (refactor)
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [ ] Deploy and open on Galaxy S24 Ultra
- [ ] Verify debug overlay appears in top-left corner
- [ ] Check displayed values (expected: width ~412px, DPR ~3, ✓ working)
- [ ] Remove component after verification complete

## Files Changed

- `src/components/DebugViewport.tsx` - Debug overlay component (new)
- `src/app/page.tsx` - Added DebugViewport component

## Note

**This is a temporary diagnostic tool.** Remove this component after confirming viewport configuration works correctly on production.
