### PR TITLE
fix(mobile): add explicit viewport meta tag and debug overlay

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -43,6 +43,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable}${inter.variable} ${merriweather.variable} antialiased bg-["#1c1c1c"] font-inter-regular`}
       >

--- a/src/components/DebugViewport.tsx
+++ b/src/components/DebugViewport.tsx
@@ -10,7 +10,7 @@ export function DebugViewport() {
     const dpr = window.devicePixelRatio;
     const physicalWidth = Math.round(width * dpr);
     const physicalHeight = Math.round(height * dpr);
-    
+
     setInfo({
       width,
       height,
@@ -38,8 +38,12 @@ export function DebugViewport() {
         borderRadius: "0 0 8px 0",
       }}
     >
-      <div>CSS: {info.width} × {info.height}px</div>
-      <div>Physical: {info.physicalWidth} × {info.physicalHeight}px</div>
+      <div>
+        CSS: {info.width} × {info.height}px
+      </div>
+      <div>
+        Physical: {info.physicalWidth} × {info.physicalHeight}px
+      </div>
       <div>DPR: {info.dpr}</div>
       <div>Mobile: {info.isMobile ? "YES" : "NO"}</div>
       <div style={{ marginTop: "8px", fontSize: "14px", color: "#ffff00" }}>

--- a/src/components/DebugViewport.tsx
+++ b/src/components/DebugViewport.tsx
@@ -5,10 +5,18 @@ export function DebugViewport() {
   const [info, setInfo] = useState<any>(null);
 
   useEffect(() => {
+    const width = window.innerWidth;
+    const height = window.innerHeight;
+    const dpr = window.devicePixelRatio;
+    const physicalWidth = Math.round(width * dpr);
+    const physicalHeight = Math.round(height * dpr);
+    
     setInfo({
-      width: window.innerWidth,
-      height: window.innerHeight,
-      dpr: window.devicePixelRatio,
+      width,
+      height,
+      dpr,
+      physicalWidth,
+      physicalHeight,
       isMobile: /Android|iPhone/i.test(navigator.userAgent),
     });
   }, []);
@@ -30,12 +38,12 @@ export function DebugViewport() {
         borderRadius: "0 0 8px 0",
       }}
     >
-      <div>Width: {info.width}px</div>
-      <div>Height: {info.height}px</div>
+      <div>CSS: {info.width} × {info.height}px</div>
+      <div>Physical: {info.physicalWidth} × {info.physicalHeight}px</div>
       <div>DPR: {info.dpr}</div>
       <div>Mobile: {info.isMobile ? "YES" : "NO"}</div>
-      <div style={{ marginTop: "8px", fontSize: "12px", color: "#888" }}>
-        {info.width < 500 ? "✓ Viewport working" : "✗ Viewport NOT working"}
+      <div style={{ marginTop: "8px", fontSize: "14px", color: "#ffff00" }}>
+        {info.width <= 600 ? "✓ Viewport working" : "⚠ Check if UI looks right"}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Fix viewport meta configuration not being applied on production by adding explicit meta tag in HTML head. Add debug overlay to verify viewport normalization is working correctly on high-DPI mobile devices like the Galaxy S24 Ultra.

## Changes

- Add explicit `<meta name="viewport">` tag directly in layout HTML head
- Keep viewport export for Next.js metadata API compatibility
- Create `DebugViewport` component showing CSS vs physical pixel dimensions
- Display DPR, mobile detection, and viewport status
- Render as fixed green overlay in top-left corner for easy on-device testing

## Type of Change

- [x] Bug fix (viewport meta not being applied)
- [x] New feature (diagnostic/debugging tool)
- [ ] Code quality improvement (refactor)
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [ ] Deploy and open on Galaxy S24 Ultra (FHD+ 2340×1080)
- [ ] Verify debug overlay appears in top-left corner
- [ ] Check displayed values:
  - CSS: Should be ~360-600px width (not 980px+)
  - Physical: Should match screen resolution
  - UI should look normal-sized and usable
- [ ] Remove debug component after verification complete

## Files Changed

- `src/app/layout.tsx` - Added explicit viewport meta tag in head
- `src/components/DebugViewport.tsx` - Debug overlay component (new)
- `src/app/page.tsx` - Added DebugViewport component

## Note

The explicit `<meta name="viewport">` tag in the head is the critical fix. The viewport export wasn't being properly applied on production, causing the 980px CSS width issue on S24 Ultra.

**Debug overlay is temporary** - remove after confirming UI renders at correct size.
