### PR TITLE
fix(mobile): enhance viewport export and add debug overlay

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,6 +34,10 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
+  minimumScale: 1,
+  maximumScale: 5,
+  userScalable: true,
+  viewportFit: "cover",
 };
 
 export default function RootLayout({
@@ -43,9 +47,6 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <head>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable}${inter.variable} ${merriweather.variable} antialiased bg-["#1c1c1c"] font-inter-regular`}
       >


### PR DESCRIPTION
## Summary

Fix viewport meta configuration not being properly applied on high-DPI mobile devices like the Galaxy S24 Ultra (2340×1080 FHD+). Remove conflicting manual head tag and enhance viewport export with explicit properties. Add debug overlay to verify viewport normalization on-device.

## Changes

- Remove manual `<head>` tag (incompatible with Next.js App Router)
- Enhance viewport export with `minimumScale`, `maximumScale`, `userScalable`, `viewportFit`
- Create `DebugViewport` component showing CSS vs physical pixel dimensions
- Display DPR, mobile detection, and viewport status
- Render as fixed green overlay in top-left corner for easy on-device testing

## Type of Change

- [x] Bug fix (viewport meta not being applied)
- [x] New feature (diagnostic/debugging tool)
- [ ] Code quality improvement (refactor)
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [ ] Deploy and open on Galaxy S24 Ultra (FHD+ 2340×1080)
- [ ] Verify debug overlay appears in top-left corner
- [ ] Check displayed values:
  - CSS: Should be ~360-600px width (not 980px+)
  - Physical: Should match screen resolution
  - UI should look normal-sized and usable
- [ ] Remove debug component after verification complete

## Files Changed

- `src/app/layout.tsx` - Enhanced viewport export, removed manual head tag
- `src/components/DebugViewport.tsx` - Debug overlay component (new)
- `src/app/page.tsx` - Added DebugViewport component

## Note

In Next.js 15 App Router, manual `<head>` tags conflict with the framework's metadata system. The correct approach is using the `viewport` export with explicit properties.

Current issue: S24 Ultra shows 980px CSS width (should be ~360-480px). This PR attempts to fix by:

1. Removing conflicting manual head tag
2. Adding explicit viewport properties
3. Using debug overlay to verify if meta tag renders in production HTML

**Debug overlay is temporary** - remove after confirming viewport normalization works correctly.
