### PR TITLE
fix(mobile): enhance viewport export and add debug overlay # corrected

### DIFF
--- a/src/components/DebugViewport.tsx
+++ b/src/components/DebugViewport.tsx
@@ -10,7 +10,11 @@ export function DebugViewport() {
     const dpr = window.devicePixelRatio;
     const physicalWidth = Math.round(width * dpr);
     const physicalHeight = Math.round(height * dpr);
-
+    
+    // Check if viewport meta tag exists
+    const viewportMeta = document.querySelector('meta[name="viewport"]');
+    const viewportContent = viewportMeta?.getAttribute('content') || 'NOT FOUND';
+    
     setInfo({
       width,
       height,
@@ -18,6 +22,8 @@ export function DebugViewport() {
       physicalWidth,
       physicalHeight,
       isMobile: /Android|iPhone/i.test(navigator.userAgent),
+      viewportContent,
+      hasViewportTag: !!viewportMeta,
     });
   }, []);
 
@@ -46,8 +52,16 @@ export function DebugViewport() {
       </div>
       <div>DPR: {info.dpr}</div>
       <div>Mobile: {info.isMobile ? "YES" : "NO"}</div>
+      <div style={{ marginTop: "8px", fontSize: "12px", borderTop: "1px solid #333", paddingTop: "8px" }}>
+        <div style={{ color: info.hasViewportTag ? "#0f0" : "#f00", fontWeight: "bold" }}>
+          Meta tag: {info.hasViewportTag ? "✓ FOUND" : "✗ MISSING"}
+        </div>
+        <div style={{ fontSize: "10px", color: "#888", marginTop: "4px", wordBreak: "break-all" }}>
+          {info.viewportContent}
+        </div>
+      </div>
       <div style={{ marginTop: "8px", fontSize: "14px", color: "#ffff00" }}>
-        {info.width <= 600 ? "✓ Viewport working" : "⚠ Check if UI looks right"}
+        {info.width <= 600 ? "✓ Viewport working" : "⚠ UI looks wrong"}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Fix viewport meta configuration not being properly applied on high-DPI mobile devices like the Galaxy S24 Ultra (2340×1080 FHD+). Remove conflicting manual head tag and enhance viewport export with explicit properties. Add debug overlay to verify viewport normalization on-device.

## Changes

- Remove manual `<head>` tag (incompatible with Next.js App Router)
- Enhance viewport export with `minimumScale`, `maximumScale`, `userScalable`, `viewportFit`
- Create `DebugViewport` component showing CSS vs physical pixel dimensions
- Inspect DOM to verify viewport meta tag actually exists in rendered HTML
- Display tag content attribute value or "NOT FOUND" if missing
- Display DPR, mobile detection, and viewport status
- Render as fixed green overlay in top-left corner for easy on-device testing

## Type of Change

- [x] Bug fix (viewport meta not being applied)
- [x] New feature (diagnostic/debugging tool)
- [ ] Code quality improvement (refactor)
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [ ] Deploy and open on Galaxy S24 Ultra (FHD+ 2340×1080)
- [ ] Verify debug overlay appears in top-left corner
- [ ] Check displayed values:
  - CSS: Should be ~360-600px width (not 980px+)
  - Physical: Should match screen resolution
  - UI should look normal-sized and usable
- [ ] Remove debug component after verification complete

## Files Changed

- `src/app/layout.tsx` - Enhanced viewport export, removed manual head tag
- `src/components/DebugViewport.tsx` - Debug overlay component (new)
- `src/app/page.tsx` - Added DebugViewport component

## Note

In Next.js 15 App Router, manual `<head>` tags conflict with the framework's metadata system. The correct approach is using the `viewport` export with explicit properties.

Current issue: S24 Ultra shows 980px CSS width (should be ~360-480px). This PR attempts to fix by:

1. Removing conflicting manual head tag
2. Adding explicit viewport properties
3. Using debug overlay to verify if meta tag renders in production HTML

**Debug overlay is temporary** - remove after confirming viewport normalization works correctly.
