### PR TITLE
fix(mobile): keep cube large using visible max dimension with margins

### DIFF
--- a/src/hooks/useResponsiveFaceSize.ts
+++ b/src/hooks/useResponsiveFaceSize.ts
@@ -92,7 +92,7 @@ export const useResponsiveFaceSize = () => {
       // console.log("Viewport corrected, recalculating size...");
       updateSize();
       // Signal that size calculation is complete after viewport fix
-      window.dispatchEvent(new CustomEvent('size-calculated'));
+      window.dispatchEvent(new CustomEvent("size-calculated"));
     };
 
     // Initial update with delay
@@ -101,11 +101,14 @@ export const useResponsiveFaceSize = () => {
     // Debounced resize handler (150ms)
     const debouncedUpdate = debounce(updateSize, 150);
     window.addEventListener("resize", debouncedUpdate);
+    // Also listen to visualViewport for accurate visible viewport changes
+    window.visualViewport?.addEventListener("resize", debouncedUpdate);
     window.addEventListener("viewport-corrected", handleViewportCorrected);
     window.addEventListener("viewport-ready", updateSize);
 
     return () => {
       window.removeEventListener("resize", debouncedUpdate);
+      window.visualViewport?.removeEventListener("resize", debouncedUpdate);
       window.removeEventListener("viewport-corrected", handleViewportCorrected);
       window.removeEventListener("viewport-ready", updateSize);
     };

--- a/src/utils/deviceDetection.ts
+++ b/src/utils/deviceDetection.ts
@@ -72,7 +72,9 @@ export function getMobileOrientation(): "portrait" | "landscape" {
     return "portrait"; // Default for SSR
   }
 
-  return window.innerWidth > window.innerHeight ? "landscape" : "portrait";
+  const vw = window.visualViewport?.width ?? window.innerWidth;
+  const vh = window.visualViewport?.height ?? window.innerHeight;
+  return vw > vh ? "landscape" : "portrait";
 }
 
 /**
@@ -102,13 +104,14 @@ export function calculateMobileCubeSize(marginPercent: number = 0.15): number {
     return 400; // Default for SSR
   }
 
-  const orientation = getMobileOrientation();
+  const vw = window.visualViewport?.width ?? window.innerWidth;
+  const vh = window.visualViewport?.height ?? window.innerHeight;
 
-  // Calculate available dimension (after margins)
-  const dimension =
-    orientation === "portrait" ? window.innerHeight : window.innerWidth;
+  // Use the larger visible dimension so the cube stays large on mobile.
+  // Letterboxing CSS will handle the smaller axis padding.
+  const dimension = Math.max(vw, vh);
 
-  // Apply margin percentage (e.g., 0.1 = 10% total, 5% each side)
+  // Apply margin percentage (e.g., 0.15 = 15% total)
   const availableSize = dimension * (1 - marginPercent);
 
   return availableSize;


### PR DESCRIPTION
Use VisualViewport and size from the larger visible axis so the cube remains prominent on mobile while CSS letterboxing handles the smaller axis. Remove previous clamp that made the cube tiny in some contexts.

Changes:
- deviceDetection.calculateMobileCubeSize: dimension = max(vw, vh); apply (1 - marginPercent) without extra clamp
- useResponsiveFaceSize: continue to listen to visualViewport resize for accurate updates on Android dynamic UI changes

Restores intended UX: large cube on phones, with letterboxing CSS containing overflow along the smaller axis.