### PR TITLE
feat(chat): enhance profile section with responsive image and polish

### DIFF
--- a/src/components/scene/chat/assistant-ui/thread.tsx
+++ b/src/components/scene/chat/assistant-ui/thread.tsx
@@ -263,7 +263,9 @@ const ThreadWelcome: FC<{ config: ChatConfig }> = ({ config }) => {
               exit={{ opacity: 0, y: 10 }}
               transition={{ delay: 0.0 }}
               className={`aui-thread-welcome-avatar relative self-stretch aspect-square ${
-                isMobile ? "h-28 w-28" : "h-35 w-35 lg:h-42 lg:w-42"
+                isMobile
+                  ? "h-28 w-28"
+                  : "h-35 w-35 lg:h-42 lg:w-42 xl:h-52 xl:w-52"
               }`}
             >
               <Tooltip>

--- a/src/components/scene/chat/assistant-ui/thread.tsx
+++ b/src/components/scene/chat/assistant-ui/thread.tsx
@@ -227,7 +227,7 @@ const FakeAssistantMessage: FC<{ text: string }> = ({ text }) => {
     >
       <div className="flex">
         <Tooltip>
-          <Avatar className="mr-3 mt-1 h-12 w-12 shadow-sm shadow-muted-foreground/10">
+          <Avatar className="mr-3 mt-1 h-12 w-12 border shadow-sm shadow-muted-foreground/10">
             <TooltipTrigger>
               <AvatarImage
                 src={`/gimli-ai/gimli-ai-avatar-${gimliChoice.choice}.webp`}
@@ -251,27 +251,36 @@ const FakeAssistantMessage: FC<{ text: string }> = ({ text }) => {
 
 const ThreadWelcome: FC<{ config: ChatConfig }> = ({ config }) => {
   const welcome_messages = config.welcome_messages;
+  const isMobile = useAtomValue(isMobileAtom);
   return (
     <ThreadPrimitive.Empty>
-      <div className="aui-thread-welcome-root mx-auto my-auto flex w-full max-w-[var(--thread-max-width)] flex-col h-full justify-around overflow-y-auto px-0 md:px-8 mobile-landscape:p-0">
+      <div className="aui-thread-welcome-root mx-auto my-auto flex w-full max-w-[var(--thread-max-width)] flex-col h-full justify-around overflow-y-auto px-0 md:px-4 mobile-landscape:p-0">
         <div className="aui-thread-welcome-center flex w-full justify-center gap-4 md:gap-6">
-          <div className="aui-thread-welcome-picture flex flex-col items-center justify-start pt-1 gap-1 md:gap-2">
+          <div className="aui-thread-welcome-picture flex flex-col items-center justify-start pt-1 gap-1.5 md:gap-2">
             <m.div
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: 10 }}
               transition={{ delay: 0.0 }}
-              className="aui-thread-welcome-avatar self-stretch aspect-square max-h-32 md:max-h-52"
+              className={`aui-thread-welcome-avatar relative self-stretch aspect-square ${
+                isMobile ? "h-28 w-28" : "h-35 w-35 lg:h-42 lg:w-42"
+              }`}
             >
-              <Image
-                src="/images/photo-lev.jpg"
-                alt="Lev Zhitnik"
-                width={128}
-                height={128}
-                className="rounded-[25px] object-cover h-full w-full grayscale-15"
-                unoptimized={true}
-                loading="lazy"
-              />
+              <Tooltip>
+                <TooltipTrigger>
+                  <Image
+                    src="/images/photo-lev.jpg"
+                    alt="Lev Zhitnik"
+                    className="rounded-[25px] object-cover h-full w-full grayscale-15 border shadow-md shadow-muted-foreground/10 hover:scale-103 transition-all duration-300 hover:shadow-lg hover:shadow-muted-foreground/20"
+                    unoptimized={true}
+                    loading="lazy"
+                    fill={true}
+                  />
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>That's me!</p>
+                </TooltipContent>
+              </Tooltip>
             </m.div>
             <m.div
               initial={{ opacity: 0, y: 10 }}
@@ -282,7 +291,7 @@ const ThreadWelcome: FC<{ config: ChatConfig }> = ({ config }) => {
             >
               <ButtonFrame
                 variant="default"
-                classNameAdditional="px-2 bg-foreground border-muted-foreground w-full"
+                classNameAdditional="px-2 bg-foreground border-muted-foreground w-full shadow-md shadow-muted-foreground/10"
                 border={false}
               >
                 <LinkButton
@@ -398,7 +407,7 @@ const ThreadWelcomeSuggestions: FC<{ suggestions: any[] }> = ({
           >
             <Button
               variant="ghost"
-              className="aui-thread-welcome-suggestion w-full h-auto hover:opacity-90 flex flex-col items-start justify-around gap-0.5 px-6 rounded-full cursor-pointer [@media(max-width:600px)_or_(max-height:600px)]:gap-0"
+              className="aui-thread-welcome-suggestion w-full h-auto hover:opacity-90 flex flex-col items-start justify-around gap-0.5 px-6 rounded-[25px] cursor-pointer [@media(max-width:600px)_or_(max-height:600px)]:gap-0 shadow-sm shadow-muted-foreground/10"
               aria-label={suggestedAction.action}
               matchBgColor={true}
             >
@@ -666,7 +675,7 @@ const AssistantMessage: FC = () => {
       >
         <div className="flex">
           <Tooltip>
-            <Avatar className="mr-3 mt-1 h-10 w-10 shadow-sm shadow-muted-foreground/10">
+            <Avatar className="mr-3 mt-1 h-10 w-10 border shadow-sm shadow-muted-foreground/10">
               <TooltipTrigger className="flex align-top justify-start">
                 <AvatarImage
                   src={`/gimli-ai/gimli-ai-avatar-${gimliChoice.choice}.webp`}

--- a/src/components/shared/ui/button.tsx
+++ b/src/components/shared/ui/button.tsx
@@ -46,8 +46,7 @@ const buttonVariants = cva(
       {
         variant: "ghost",
         matchBgColor: true,
-        class:
-          "bg-[var(--dynamic-bg)] hover:bg-[var(--dynamic-bg)]/50 dark:hover:!bg-white/70 transition-colors ease-in-out",
+        class: "bg-[var(--dynamic-bg)] transition-colors ease-in-out",
       },
     ],
     defaultVariants: {


### PR DESCRIPTION
## Summary
Enhanced the chat welcome section with a profile photo, responsive layout, and visual polish improvements including tooltips, refined shadows, and improved button states.

## Type of Change
- [x] New feature (non-breaking change adding functionality)
- [x] UI Polish (visual/UX improvements)
- [ ] Bug fix
- [ ] Breaking change

## Changes
- Added profile photo with responsive sizing and mobile breakpoints
- Implemented hover tooltip on profile image
- Enhanced avatars and cards with borders and refined shadows
- Improved button visual hierarchy and hover states
- Optimized image rendering with Next.js Image fill prop
- Updated Jotai dependency override for version consistency

## Files Changed
- `src/components/scene/chat/assistant-ui/thread.tsx` - Profile image, tooltips, and layout enhancements
- `public/images/photo-lev.jpg` - New profile image asset
- `src/components/shared/ButtonFrame.tsx` - Spacing adjustment
- `src/components/shared/ui/button.tsx` - Simplified ghost button hover
- `package.json` - Jotai override configuration

## Testing
- Verify profile image displays correctly at all breakpoints
- Test tooltip hover interaction on profile image
- Check button hover states and visual feedback
- Confirm responsive layout on mobile and desktop