### PR TITLE
fix(mobile): implement dynamic keyboard padding using viewport metrics

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -111,10 +111,6 @@
   --page-resume: #e6c9b5;
   --page-secret: #e4dfda;
   --viewport-height: 100vh;
-  /* Mobile keyboard + bottom margin metrics (set at runtime) */
-  --keyboard-inset: 0px;
-  --mobile-bottom-margin: 0px;
-  --kb-pad: 0px;
 
   /* Responsive face padding for mobile/tablet letterboxing */
   /* Vertical padding: when face is taller than viewport + 10px margin */
@@ -130,16 +126,7 @@
   --face-padding-base: 1rem;
 }
 
-/* Mobile keyboard-aware padding utility */
-.kb-pad {
-  padding-bottom: calc(
-    var(--kb-pad, 0px) + var(--kb-extra, 0px) + env(safe-area-inset-bottom)
-  );
-}
-
-/* Optional per-page extra padding shims */
-.kb-extra-chat { --kb-extra: 12px; }
-.kb-extra-contact { --kb-extra: 48px; }
+/* (Removed keyboard padding utilities per revert) */
 
 .dark {
   --background: oklch(0.205 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -131,9 +131,15 @@
 }
 
 /* Mobile keyboard-aware padding utility */
-.kb-pad { 
-  padding-bottom: calc(var(--kb-pad, 0px) + env(safe-area-inset-bottom));
+.kb-pad {
+  padding-bottom: calc(
+    var(--kb-pad, 0px) + var(--kb-extra, 0px) + env(safe-area-inset-bottom)
+  );
 }
+
+/* Optional per-page extra padding shims */
+.kb-extra-chat { --kb-extra: 12px; }
+.kb-extra-contact { --kb-extra: 48px; }
 
 .dark {
   --background: oklch(0.205 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -111,6 +111,10 @@
   --page-resume: #e6c9b5;
   --page-secret: #e4dfda;
   --viewport-height: 100vh;
+  /* Mobile keyboard + bottom margin metrics (set at runtime) */
+  --keyboard-inset: 0px;
+  --mobile-bottom-margin: 0px;
+  --kb-pad: 0px;
 
   /* Responsive face padding for mobile/tablet letterboxing */
   /* Vertical padding: when face is taller than viewport + 10px margin */
@@ -124,6 +128,11 @@
   --face-padding-x: max(0px, calc(((var(--face-size) - 100vw) / 2) + 20px));
   /* Minimal padding for desktop (always applies) */
   --face-padding-base: 1rem;
+}
+
+/* Mobile keyboard-aware padding utility */
+.kb-pad { 
+  padding-bottom: calc(var(--kb-pad, 0px) + env(safe-area-inset-bottom));
 }
 
 .dark {

--- a/src/atoms/atomStore.ts
+++ b/src/atoms/atomStore.ts
@@ -83,6 +83,7 @@ export const viewportOrientationAtom = atom<"portrait" | "landscape">(
 
 // Mobile Keyboard UX
 export const keyboardVisibleAtom = atom<boolean>(false);
+export const keyboardHeightAtom = atom<number>(0);
 
 // Projects Gallery
 export const projectViewAtom = atom<"project" | "zoomed">("project");

--- a/src/components/scene/CameraController.tsx
+++ b/src/components/scene/CameraController.tsx
@@ -14,21 +14,6 @@ export const CameraController = () => {
       return;
     }
 
-    // Debug logs - commented out for production
-    // console.log('camera', camera);
-    // console.log('size', size);
-    // console.log('viewport', viewport);
-    // console.log('scene', scene);
-    // console.log('setSize', setSize);
-
-    // const perspCamera = camera as THREE.PerspectiveCamera;
-    // const viewportHeight = size.height || window.innerHeight || 1;
-    // const distance = calculateDistanceForSize(cubeSize, faceSize, perspCamera, viewportHeight);
-
-    // perspCamera.position.set(0, 0, distance);
-    // perspCamera.lookAt(0, 0, 0);
-    // perspCamera.updateProjectionMatrix();
-
     if (isLoaded) {
       return;
     }

--- a/src/components/scene/chat/assistant-ui/thread.tsx
+++ b/src/components/scene/chat/assistant-ui/thread.tsx
@@ -30,8 +30,6 @@ import {
   gimliChoiceAtom,
   isMobileAtom,
   keyboardVisibleAtom,
-  viewportHeightAtom,
-  viewportOrientationAtom,
   pushNavigationCallbackAtom,
 } from "@/atoms/atomStore";
 import { UserMessageAttachments } from "@/components/scene/chat/assistant-ui/attachment";
@@ -107,35 +105,6 @@ const ChatBackButton: FC = () => {
 export const Thread: FC = () => {
   const isMobile = useAtomValue(isMobileAtom);
   const keyboardVisible = useAtomValue(keyboardVisibleAtom);
-  const baselineHeight = useAtomValue(viewportHeightAtom);
-  const orientation = useAtomValue(viewportOrientationAtom);
-  const [vvh, setVvh] = useState<number>(0);
-
-  // Keep visualViewport height updated for inline padding calc
-  useEffect(() => {
-    const update = () => {
-      setVvh(
-        typeof window !== "undefined" ? window.visualViewport?.height ?? 0 : 0
-      );
-    };
-    update();
-    window.visualViewport?.addEventListener("resize", update);
-    return () => window.visualViewport?.removeEventListener("resize", update);
-  }, []);
-
-  // Scroll composer into view just above keyboard when it opens
-  useEffect(() => {
-    if (!isMobile || !keyboardVisible) return;
-    const t = setTimeout(() => {
-      const el = document.querySelector(
-        ".aui-composer-wrapper"
-      ) as HTMLElement | null;
-      if (el) {
-        el.scrollIntoView({ behavior: "smooth", block: "end", inline: "nearest" });
-      }
-    }, 120);
-    return () => clearTimeout(t);
-  }, [isMobile, keyboardVisible, vvh]);
 
   // Reverted: no dynamic keyboard padding logic
 
@@ -167,22 +136,8 @@ export const Thread: FC = () => {
               <ThreadPrimitive.Viewport
                 className={cn(
                   "aui-thread-viewport relative flex flex-1 flex-col overflow-x-auto overflow-y-auto",
-                  // Fallback while vv is unavailable
-                  isMobile && keyboardVisible && "pb-[30dvh]"
+                  isMobile && keyboardVisible && "pb-[40dvh]"
                 )}
-                style={
-                  isMobile && keyboardVisible && vvh > 0
-                    ? (() => {
-                        const dvh =
-                          baselineHeight ||
-                          (typeof window !== "undefined" ? window.innerHeight : 0);
-                        const margin = orientation === "portrait" ? 0.15 * dvh : 0;
-                        const GAP = 32; // 2rem breathing room
-                        const pad = Math.max(0, dvh - margin - vvh + GAP);
-                        return { paddingBottom: `${pad}px` };
-                      })()
-                    : undefined
-                }
               >
                 {chatConfig && <ThreadWelcome config={chatConfig} />}
 

--- a/src/components/scene/chat/assistant-ui/thread.tsx
+++ b/src/components/scene/chat/assistant-ui/thread.tsx
@@ -104,9 +104,6 @@ const ChatBackButton: FC = () => {
 
 export const Thread: FC = () => {
   const isMobile = useAtomValue(isMobileAtom);
-  const keyboardVisible = useAtomValue(keyboardVisibleAtom);
-  const wrapperRef = useRef<HTMLDivElement>(null);
-  // Reverted: no dynamic keyboard padding logic
 
   const {
     data: chatConfig,
@@ -121,43 +118,6 @@ export const Thread: FC = () => {
   });
 
   if (error) return <FailedLoad />;
-
-  // Scroll focused input into view when keyboard appears on mobile
-  useEffect(() => {
-    if (!isMobile) return;
-
-    const handleFocus = (e: FocusEvent) => {
-      const target = e.target as HTMLElement;
-      if (target.tagName === "INPUT" || target.tagName === "TEXTAREA") {
-        // Find the FormItem parent that contains both label and input
-        const formItem = target.closest('[data-slot="form-item"]');
-
-        // Small delay to ensure keyboard is fully visible and padding is applied
-        setTimeout(() => {
-          if (formItem) {
-            formItem.scrollIntoView({
-              behavior: "smooth",
-              block: "start",
-              inline: "nearest",
-            });
-          } else {
-            // Fallback to input if FormItem not found
-            target.scrollIntoView({
-              behavior: "smooth",
-              block: "start",
-              inline: "nearest",
-            });
-          }
-        }, 50);
-      }
-    };
-
-    const wrapper = wrapperRef.current;
-    if (wrapper) {
-      wrapper.addEventListener("focusin", handleFocus);
-      return () => wrapper.removeEventListener("focusin", handleFocus);
-    }
-  }, [isMobile]);
 
   return (
     <div className="relative h-full">
@@ -538,7 +498,7 @@ const Composer: FC<{ chatConfig: ChatConfig | null; isLoading: boolean }> = ({
       <div
         className={cn(
           "aui-composer-wrapper sticky bottom-0 mx-auto flex w-full max-w-[var(--thread-max-width)] flex-col overflow-visible rounded-t-md bg-background pb-4 md:px-4 md:pb-6 mobile-landscape:p-0",
-          isMobile && keyboardVisible && "pb-[60dvh]"
+          isMobile && keyboardVisible && "pb-[30dvh]"
         )}
       >
         <ThreadScrollToBottom />

--- a/src/components/scene/chat/assistant-ui/thread.tsx
+++ b/src/components/scene/chat/assistant-ui/thread.tsx
@@ -30,6 +30,7 @@ import {
   gimliChoiceAtom,
   isMobileAtom,
   keyboardVisibleAtom,
+  keyboardHeightAtom,
   pushNavigationCallbackAtom,
 } from "@/atoms/atomStore";
 import { UserMessageAttachments } from "@/components/scene/chat/assistant-ui/attachment";
@@ -105,6 +106,7 @@ const ChatBackButton: FC = () => {
 export const Thread: FC = () => {
   const isMobile = useAtomValue(isMobileAtom);
   const keyboardVisible = useAtomValue(keyboardVisibleAtom);
+  const keyboardHeight = useAtomValue(keyboardHeightAtom);
 
   const {
     data: chatConfig,
@@ -132,10 +134,10 @@ export const Thread: FC = () => {
           <MotionConfig reducedMotion="user">
             <ThreadPrimitive.Root className="aui-root aui-thread-root @container flex h-full flex-col bg-background">
               <ThreadPrimitive.Viewport
-                className={cn(
-                  "aui-thread-viewport relative flex flex-1 flex-col overflow-x-auto overflow-y-auto",
-                  isMobile && keyboardVisible && "pb-[40dvh]"
-                )}
+                className="aui-thread-viewport relative flex flex-1 flex-col overflow-x-auto overflow-y-auto"
+                style={{
+                  paddingBottom: isMobile && keyboardVisible ? `${keyboardHeight}px` : '0',
+                }}
               >
                 {chatConfig && <ThreadWelcome config={chatConfig} />}
 
@@ -322,7 +324,7 @@ const ThreadWelcome: FC<{ config: ChatConfig }> = ({ config }) => {
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: 10 }}
-              className="aui-thread-welcome-message-motion-1 font-merriweather font-bold text-lg [@media(min-width:700px)_and_(min-height:700px)]:text-xl [@media(min-width:800px)_and_(min-height:800px)]:text-2xl mb-2"
+              className="aui-thread-welcome-message-motion-1 font-merriweather font-bold text-lg [@media(min-width:700px)_and_(min-height:700px)]:text-xl [@media(min-width:800px)_and_(min-height:800px)]:text-2xl md:mb-2"
             >
               {
                 welcome_messages.filter(

--- a/src/components/scene/chat/assistant-ui/thread.tsx
+++ b/src/components/scene/chat/assistant-ui/thread.tsx
@@ -136,7 +136,7 @@ export const Thread: FC = () => {
               <ThreadPrimitive.Viewport
                 className={cn(
                   "aui-thread-viewport relative flex flex-1 flex-col overflow-x-auto overflow-y-auto",
-                  isMobile && keyboardVisible && "pb-[35dvh]"
+                  isMobile && keyboardVisible && "pb-[60dvh]"
                 )}
               >
                 {chatConfig && <ThreadWelcome config={chatConfig} />}

--- a/src/components/scene/chat/assistant-ui/thread.tsx
+++ b/src/components/scene/chat/assistant-ui/thread.tsx
@@ -30,6 +30,8 @@ import {
   gimliChoiceAtom,
   isMobileAtom,
   keyboardVisibleAtom,
+  viewportHeightAtom,
+  viewportOrientationAtom,
   pushNavigationCallbackAtom,
 } from "@/atoms/atomStore";
 import { UserMessageAttachments } from "@/components/scene/chat/assistant-ui/attachment";
@@ -105,6 +107,35 @@ const ChatBackButton: FC = () => {
 export const Thread: FC = () => {
   const isMobile = useAtomValue(isMobileAtom);
   const keyboardVisible = useAtomValue(keyboardVisibleAtom);
+  const baselineHeight = useAtomValue(viewportHeightAtom);
+  const orientation = useAtomValue(viewportOrientationAtom);
+  const [vvh, setVvh] = useState<number>(0);
+
+  // Keep visualViewport height updated for inline padding calc
+  useEffect(() => {
+    const update = () => {
+      setVvh(
+        typeof window !== "undefined" ? window.visualViewport?.height ?? 0 : 0
+      );
+    };
+    update();
+    window.visualViewport?.addEventListener("resize", update);
+    return () => window.visualViewport?.removeEventListener("resize", update);
+  }, []);
+
+  // Scroll composer into view just above keyboard when it opens
+  useEffect(() => {
+    if (!isMobile || !keyboardVisible) return;
+    const t = setTimeout(() => {
+      const el = document.querySelector(
+        ".aui-composer-wrapper"
+      ) as HTMLElement | null;
+      if (el) {
+        el.scrollIntoView({ behavior: "smooth", block: "end", inline: "nearest" });
+      }
+    }, 120);
+    return () => clearTimeout(t);
+  }, [isMobile, keyboardVisible, vvh]);
 
   // Reverted: no dynamic keyboard padding logic
 
@@ -136,8 +167,22 @@ export const Thread: FC = () => {
               <ThreadPrimitive.Viewport
                 className={cn(
                   "aui-thread-viewport relative flex flex-1 flex-col overflow-x-auto overflow-y-auto",
-                  isMobile && keyboardVisible && "pb-[40dvh]"
+                  // Fallback while vv is unavailable
+                  isMobile && keyboardVisible && "pb-[30dvh]"
                 )}
+                style={
+                  isMobile && keyboardVisible && vvh > 0
+                    ? (() => {
+                        const dvh =
+                          baselineHeight ||
+                          (typeof window !== "undefined" ? window.innerHeight : 0);
+                        const margin = orientation === "portrait" ? 0.15 * dvh : 0;
+                        const GAP = 32; // 2rem breathing room
+                        const pad = Math.max(0, dvh - margin - vvh + GAP);
+                        return { paddingBottom: `${pad}px` };
+                      })()
+                    : undefined
+                }
               >
                 {chatConfig && <ThreadWelcome config={chatConfig} />}
 

--- a/src/components/scene/chat/assistant-ui/thread.tsx
+++ b/src/components/scene/chat/assistant-ui/thread.tsx
@@ -498,7 +498,7 @@ const Composer: FC<{ chatConfig: ChatConfig | null; isLoading: boolean }> = ({
       <div
         className={cn(
           "aui-composer-wrapper sticky bottom-0 mx-auto flex w-full max-w-[var(--thread-max-width)] flex-col overflow-visible rounded-t-md bg-background pb-4 md:px-4 md:pb-6 mobile-landscape:p-0",
-          isMobile && keyboardVisible && "pb-[30dvh]"
+          isMobile && keyboardVisible && "pb-[40dvh]"
         )}
       >
         <ThreadScrollToBottom />

--- a/src/components/scene/chat/assistant-ui/thread.tsx
+++ b/src/components/scene/chat/assistant-ui/thread.tsx
@@ -229,7 +229,7 @@ const FakeAssistantMessage: FC<{ text: string }> = ({ text }) => {
     >
       <div className="flex">
         <Tooltip>
-          <Avatar className="mr-3 mt-1 h-12 w-12 border shadow-sm shadow-muted-foreground/10">
+          <Avatar className="mr-3 mt-1 h-12 w-12 ">
             <TooltipTrigger>
               <AvatarImage
                 src={`/gimli-ai/gimli-ai-avatar-${gimliChoice.choice}.webp`}
@@ -275,7 +275,7 @@ const ThreadWelcome: FC<{ config: ChatConfig }> = ({ config }) => {
                   <Image
                     src="/images/photo-lev.jpg"
                     alt="Lev Zhitnik"
-                    className="rounded-[25px] object-cover h-full w-full grayscale-15 border shadow-lg shadow-muted-foreground/10 dark:shadow-muted-foreground/2 hover:scale-102 transition-all duration-300 hover:shadow-md hover:animate-jiggle hover:grayscale-0"
+                    className="rounded-[25px] object-cover h-full w-full hover:scale-102 transition-all duration-300 hover:shadow-xl shadow-muted-foreground/30 dark:shadow-none hover:animate-jiggle"
                     unoptimized={true}
                     loading="lazy"
                     fill={true}
@@ -679,7 +679,7 @@ const AssistantMessage: FC = () => {
       >
         <div className="flex">
           <Tooltip>
-            <Avatar className="mr-3 mt-1 h-10 w-10 border shadow-sm shadow-muted-foreground/10">
+            <Avatar className="mr-3 mt-1 h-10 w-10">
               <TooltipTrigger className="flex align-top justify-start">
                 <AvatarImage
                   src={`/gimli-ai/gimli-ai-avatar-${gimliChoice.choice}.webp`}

--- a/src/components/scene/chat/assistant-ui/thread.tsx
+++ b/src/components/scene/chat/assistant-ui/thread.tsx
@@ -122,6 +122,25 @@ export const Thread: FC = () => {
     return () => window.visualViewport?.removeEventListener("resize", update);
   }, []);
 
+  // Scroll composer into view above the keyboard when it opens
+  useEffect(() => {
+    if (!isMobile || !keyboardVisible) return;
+    const scroll = () => {
+      const el = document.querySelector(
+        ".aui-composer-wrapper"
+      ) as HTMLElement | null;
+      if (el) {
+        el.scrollIntoView({
+          behavior: "smooth",
+          block: "end",
+          inline: "nearest",
+        });
+      }
+    };
+    const t = setTimeout(scroll, 120);
+    return () => clearTimeout(t);
+  }, [isMobile, keyboardVisible, vvh]);
+
   const {
     data: chatConfig,
     isLoading,
@@ -166,8 +185,9 @@ export const Thread: FC = () => {
                             ? window.visualViewport?.height ?? 0
                             : 0);
                         const margin =
-                          orientation === "portrait" ? 0.075 * dvh : 0;
-                        const pad = Math.max(0, dvh - vv - margin);
+                          orientation === "portrait" ? 0.15 * dvh : 0;
+                        const GAP = 32; // 2rem breathing room
+                        const pad = Math.max(0, dvh - vv - margin - GAP);
                         return { paddingBottom: `${pad}px` };
                       })()
                     : undefined

--- a/src/components/scene/chat/assistant-ui/thread.tsx
+++ b/src/components/scene/chat/assistant-ui/thread.tsx
@@ -136,7 +136,7 @@ export const Thread: FC = () => {
               <ThreadPrimitive.Viewport
                 className={cn(
                   "aui-thread-viewport relative flex flex-1 flex-col overflow-x-auto overflow-y-auto",
-                  isMobile && keyboardVisible && "pb-[40dvh]"
+                  isMobile && keyboardVisible && "pb-[35dvh]"
                 )}
               >
                 {chatConfig && <ThreadWelcome config={chatConfig} />}

--- a/src/components/scene/chat/assistant-ui/thread.tsx
+++ b/src/components/scene/chat/assistant-ui/thread.tsx
@@ -26,13 +26,7 @@ import { domAnimation, LazyMotion, MotionConfig } from "motion/react";
 import * as m from "motion/react-m";
 import { type FC, useEffect, useRef, useState } from "react";
 import useSWR from "swr";
-import {
-  gimliChoiceAtom,
-  isMobileAtom,
-  keyboardVisibleAtom,
-  keyboardHeightAtom,
-  pushNavigationCallbackAtom,
-} from "@/atoms/atomStore";
+import { gimliChoiceAtom, isMobileAtom, pushNavigationCallbackAtom } from "@/atoms/atomStore";
 import { UserMessageAttachments } from "@/components/scene/chat/assistant-ui/attachment";
 import { MarkdownText } from "@/components/scene/chat/assistant-ui/markdown-text";
 import { ToolFallback } from "@/components/scene/chat/assistant-ui/tool-fallback";
@@ -105,8 +99,6 @@ const ChatBackButton: FC = () => {
 
 export const Thread: FC = () => {
   const isMobile = useAtomValue(isMobileAtom);
-  const keyboardVisible = useAtomValue(keyboardVisibleAtom);
-  const keyboardHeight = useAtomValue(keyboardHeightAtom);
 
   const {
     data: chatConfig,
@@ -134,10 +126,10 @@ export const Thread: FC = () => {
           <MotionConfig reducedMotion="user">
             <ThreadPrimitive.Root className="aui-root aui-thread-root @container flex h-full flex-col bg-background">
               <ThreadPrimitive.Viewport
-                className="aui-thread-viewport relative flex flex-1 flex-col overflow-x-auto overflow-y-auto"
-                style={{
-                  paddingBottom: isMobile && keyboardVisible ? `${keyboardHeight}px` : undefined,
-                }}
+                className={cn(
+                  "aui-thread-viewport relative flex flex-1 flex-col overflow-x-auto overflow-y-auto",
+                  isMobile && "kb-pad"
+                )}
               >
                 {chatConfig && <ThreadWelcome config={chatConfig} />}
 

--- a/src/components/scene/chat/assistant-ui/thread.tsx
+++ b/src/components/scene/chat/assistant-ui/thread.tsx
@@ -26,7 +26,7 @@ import { domAnimation, LazyMotion, MotionConfig } from "motion/react";
 import * as m from "motion/react-m";
 import { type FC, useEffect, useRef, useState } from "react";
 import useSWR from "swr";
-import { gimliChoiceAtom, isMobileAtom, pushNavigationCallbackAtom } from "@/atoms/atomStore";
+import { gimliChoiceAtom, isMobileAtom, keyboardVisibleAtom, pushNavigationCallbackAtom } from "@/atoms/atomStore";
 import { UserMessageAttachments } from "@/components/scene/chat/assistant-ui/attachment";
 import { MarkdownText } from "@/components/scene/chat/assistant-ui/markdown-text";
 import { ToolFallback } from "@/components/scene/chat/assistant-ui/tool-fallback";
@@ -99,6 +99,7 @@ const ChatBackButton: FC = () => {
 
 export const Thread: FC = () => {
   const isMobile = useAtomValue(isMobileAtom);
+  const keyboardVisible = useAtomValue(keyboardVisibleAtom);
 
   const {
     data: chatConfig,
@@ -128,7 +129,7 @@ export const Thread: FC = () => {
               <ThreadPrimitive.Viewport
                 className={cn(
                   "aui-thread-viewport relative flex flex-1 flex-col overflow-x-auto overflow-y-auto",
-                  isMobile && "kb-pad"
+                  isMobile && keyboardVisible && "kb-pad kb-extra-chat"
                 )}
               >
                 {chatConfig && <ThreadWelcome config={chatConfig} />}

--- a/src/components/scene/chat/assistant-ui/thread.tsx
+++ b/src/components/scene/chat/assistant-ui/thread.tsx
@@ -136,7 +136,7 @@ export const Thread: FC = () => {
               <ThreadPrimitive.Viewport
                 className="aui-thread-viewport relative flex flex-1 flex-col overflow-x-auto overflow-y-auto"
                 style={{
-                  paddingBottom: isMobile && keyboardVisible ? `${keyboardHeight}px` : '0',
+                  paddingBottom: isMobile && keyboardVisible ? `${keyboardHeight}px` : undefined,
                 }}
               >
                 {chatConfig && <ThreadWelcome config={chatConfig} />}

--- a/src/components/scene/contact/ContactForm.tsx
+++ b/src/components/scene/contact/ContactForm.tsx
@@ -8,7 +8,7 @@ import * as m from "motion/react-m";
 import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 
-import { isMobileAtom, keyboardVisibleAtom, keyboardHeightAtom } from "@/atoms/atomStore";
+import { isMobileAtom } from "@/atoms/atomStore";
 import { Button } from "@/components/shared/ui/button";
 import { CheckIcon } from "lucide-react";
 import {
@@ -32,8 +32,6 @@ import { useAnalytics } from "@/hooks/useAnalytics";
 
 const ContactForm = () => {
   const isMobile = useAtomValue(isMobileAtom);
-  const keyboardVisible = useAtomValue(keyboardVisibleAtom);
-  const keyboardHeight = useAtomValue(keyboardHeightAtom);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const trackEvent = useAnalytics();
 
@@ -144,10 +142,10 @@ const ContactForm = () => {
       <LazyMotion features={domAnimation}>
         <div
           ref={wrapperRef}
-          className="flex flex-col items-center justify-start h-full w-full px-2 pt-2 gap-2 overflow-y-auto"
-          style={{
-            paddingBottom: isMobile && keyboardVisible ? `${keyboardHeight}px` : undefined,
-          }}
+          className={cn(
+            "flex flex-col items-center justify-start h-full w-full px-2 pt-2 gap-2 overflow-y-auto",
+            isMobile && "kb-pad"
+          )}
         >
           <m.div
             initial={{ opacity: 0, y: 10 }}

--- a/src/components/scene/contact/ContactForm.tsx
+++ b/src/components/scene/contact/ContactForm.tsx
@@ -146,7 +146,7 @@ const ContactForm = () => {
           ref={wrapperRef}
           className="flex flex-col items-center justify-start h-full w-full px-2 pt-2 gap-2 overflow-y-auto"
           style={{
-            paddingBottom: isMobile && keyboardVisible ? `${keyboardHeight}px` : '0',
+            paddingBottom: isMobile && keyboardVisible ? `${keyboardHeight}px` : undefined,
           }}
         >
           <m.div

--- a/src/components/scene/contact/ContactForm.tsx
+++ b/src/components/scene/contact/ContactForm.tsx
@@ -8,7 +8,7 @@ import * as m from "motion/react-m";
 import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 
-import { isMobileAtom } from "@/atoms/atomStore";
+import { isMobileAtom, keyboardVisibleAtom } from "@/atoms/atomStore";
 import { Button } from "@/components/shared/ui/button";
 import { CheckIcon } from "lucide-react";
 import {
@@ -32,6 +32,7 @@ import { useAnalytics } from "@/hooks/useAnalytics";
 
 const ContactForm = () => {
   const isMobile = useAtomValue(isMobileAtom);
+  const keyboardVisible = useAtomValue(keyboardVisibleAtom);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const trackEvent = useAnalytics();
 
@@ -144,7 +145,7 @@ const ContactForm = () => {
           ref={wrapperRef}
           className={cn(
             "flex flex-col items-center justify-start h-full w-full px-2 pt-2 gap-2 overflow-y-auto",
-            isMobile && "kb-pad"
+            isMobile && keyboardVisible && "kb-pad kb-extra-contact"
           )}
         >
           <m.div

--- a/src/components/scene/contact/ContactForm.tsx
+++ b/src/components/scene/contact/ContactForm.tsx
@@ -79,7 +79,7 @@ const ContactForm = () => {
               inline: "nearest",
             });
           }
-        }, 350);
+        }, 100);
       }
     };
 

--- a/src/components/scene/contact/ContactForm.tsx
+++ b/src/components/scene/contact/ContactForm.tsx
@@ -145,7 +145,7 @@ const ContactForm = () => {
           ref={wrapperRef}
           className={cn(
             "flex flex-col items-center justify-start h-full w-full px-2 pt-2 gap-2 overflow-y-auto",
-            isMobile && keyboardVisible && "kb-pad kb-extra-contact"
+            isMobile && keyboardVisible && "pb-[60dvh]"
           )}
         >
           <m.div

--- a/src/components/scene/contact/ContactForm.tsx
+++ b/src/components/scene/contact/ContactForm.tsx
@@ -8,7 +8,7 @@ import * as m from "motion/react-m";
 import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 
-import { isMobileAtom, keyboardVisibleAtom } from "@/atoms/atomStore";
+import { isMobileAtom, keyboardVisibleAtom, keyboardHeightAtom } from "@/atoms/atomStore";
 import { Button } from "@/components/shared/ui/button";
 import { CheckIcon } from "lucide-react";
 import {
@@ -33,6 +33,7 @@ import { useAnalytics } from "@/hooks/useAnalytics";
 const ContactForm = () => {
   const isMobile = useAtomValue(isMobileAtom);
   const keyboardVisible = useAtomValue(keyboardVisibleAtom);
+  const keyboardHeight = useAtomValue(keyboardHeightAtom);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const trackEvent = useAnalytics();
 
@@ -143,10 +144,10 @@ const ContactForm = () => {
       <LazyMotion features={domAnimation}>
         <div
           ref={wrapperRef}
-          className={cn(
-            "flex flex-col items-center justify-start h-full w-full px-2 pt-2 gap-2 overflow-y-auto",
-            isMobile && keyboardVisible && "pb-[60dvh]"
-          )}
+          className="flex flex-col items-center justify-start h-full w-full px-2 pt-2 gap-2 overflow-y-auto"
+          style={{
+            paddingBottom: isMobile && keyboardVisible ? `${keyboardHeight}px` : '0',
+          }}
         >
           <m.div
             initial={{ opacity: 0, y: 10 }}

--- a/src/components/shared/Face.tsx
+++ b/src/components/shared/Face.tsx
@@ -1,13 +1,9 @@
 import type React from "react";
 
-export const Face = ({
-	children,
-}: {
-	children: React.ReactNode;
-}) => {
-	return (
-		<div className="cube-face bg-background flex justify-center items-center overflow-hidden">
-			<div className="face-content flex w-full h-full">{children}</div>
-		</div>
-	);
+export const Face = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <div className="cube-face bg-background flex justify-center items-center overflow-hidden">
+      <div className="face-content flex w-full h-full">{children}</div>
+    </div>
+  );
 };

--- a/src/components/shared/TooltipButton.tsx
+++ b/src/components/shared/TooltipButton.tsx
@@ -37,8 +37,8 @@ export const TooltipButton = ({
     height: `${height || size / 4}rem`,
     borderRadius: `${round ? "50%" : "25px"}`,
     cursor: "pointer",
-    padding: "0",
-    margin: "0",
+    padding: "1",
+    margin: "1",
   };
   return (
     <Tooltip>

--- a/src/components/shared/TooltipButton.tsx
+++ b/src/components/shared/TooltipButton.tsx
@@ -37,8 +37,8 @@ export const TooltipButton = ({
     height: `${height || size / 4}rem`,
     borderRadius: `${round ? "50%" : "25px"}`,
     cursor: "pointer",
-    padding: "1",
-    margin: "1",
+    padding: "0",
+    margin: "0",
   };
   return (
     <Tooltip>

--- a/src/components/shared/ui/button.tsx
+++ b/src/components/shared/ui/button.tsx
@@ -46,7 +46,7 @@ const buttonVariants = cva(
         variant: "ghost",
         matchBgColor: true,
         class:
-          "bg-[var(--dynamic-bg)] hover:bg-[var(--dynamic-bg)]/75 transition-colors ease-in-out",
+          "bg-linear-to-tr from-[var(--dynamic-bg)] to-[var(--dynamic-bg)]/80 hover:bg-[var(--dynamic-bg)]/75 transition-colors ease-in-out",
       },
     ],
     defaultVariants: {

--- a/src/components/shared/ui/button.tsx
+++ b/src/components/shared/ui/button.tsx
@@ -46,7 +46,7 @@ const buttonVariants = cva(
         variant: "ghost",
         matchBgColor: true,
         class:
-          "bg-linear-to-tr from-[var(--dynamic-bg)] to-[var(--dynamic-bg)]/80 hover:bg-[var(--dynamic-bg)]/75 transition-colors ease-in-out",
+          "bg-linear-to-tr from-[var(--dynamic-bg)] to-[var(--dynamic-bg)]/60 hover:bg-[var(--dynamic-bg)]/75 transition-colors ease-in-out",
       },
     ],
     defaultVariants: {

--- a/src/hooks/useViewportMetrics.ts
+++ b/src/hooks/useViewportMetrics.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef } from "react";
 import {
   isMobileAtom,
   keyboardVisibleAtom,
+  keyboardHeightAtom,
   viewportHeightAtom,
   viewportOrientationAtom,
   viewportWidthAtom,
@@ -54,6 +55,7 @@ export const useViewportMetrics = () => {
   const setOrientation = useSetAtom(viewportOrientationAtom);
   const setIsMobile = useSetAtom(isMobileAtom);
   const setKeyboardVisible = useSetAtom(keyboardVisibleAtom);
+  const setKeyboardHeight = useSetAtom(keyboardHeightAtom);
 
   const maxHeightRef = useRef<{ portrait: number; landscape: number }>({
     portrait: 0,
@@ -138,12 +140,18 @@ export const useViewportMetrics = () => {
         maxHeightRef.current[orientation] = stableHeight;
       }
 
+      // Calculate keyboard height: difference between stable and current viewport
+      const keyboardHeight = keyboardVisible
+        ? Math.max(0, stableHeight - height)
+        : 0;
+
       root.style.setProperty("--viewport-height", `${stableHeight}px`);
 
       setViewportHeight(stableHeight);
       setViewportWidth(width);
       setOrientation(orientation);
       setIsMobile(isMobileDevice({ width, height }));
+      setKeyboardHeight(keyboardHeight);
     };
 
     const scheduleUpdate = (reset = false) => {
@@ -246,5 +254,6 @@ export const useViewportMetrics = () => {
     setViewportWidth,
     isKeyboardElement,
     setKeyboardVisible,
+    setKeyboardHeight,
   ]);
 };

--- a/src/hooks/useViewportMetrics.ts
+++ b/src/hooks/useViewportMetrics.ts
@@ -123,7 +123,9 @@ export const useViewportMetrics = () => {
       );
       orientationRef.current = orientation;
 
-      if (reset || !keyboardVisible) {
+      // Only reset baseline when keyboard is not visible.
+      // This preserves the last known full-height baseline across keyboard toggles.
+      if (reset && !keyboardVisible) {
         maxHeightRef.current[orientation] = 0;
       }
 
@@ -152,8 +154,10 @@ export const useViewportMetrics = () => {
       const bottomMargin =
         orientation === "portrait" ? Math.round(stableHeight * 0.075) : 0;
       root.style.setProperty("--mobile-bottom-margin", `${bottomMargin}px`);
+      // Keyboard padding should exclude existing bottom margin:
+      // we only need the portion of the keyboard that intrudes into the content area
       const pad = keyboardVisible
-        ? Math.max(0, keyboardHeight + bottomMargin)
+        ? Math.max(0, keyboardHeight - bottomMargin)
         : 0;
       root.style.setProperty("--kb-pad", `${pad}px`);
 
@@ -182,7 +186,8 @@ export const useViewportMetrics = () => {
       }
       keyboardVisibleRef.current = visible;
       setKeyboardVisible(visible);
-      scheduleUpdate(true);
+      // Do not reset baseline on keyboard visibility toggles
+      scheduleUpdate(false);
     };
 
     const handleFocusIn = (event: FocusEvent) => {

--- a/src/hooks/useViewportMetrics.ts
+++ b/src/hooks/useViewportMetrics.ts
@@ -146,6 +146,16 @@ export const useViewportMetrics = () => {
         : 0;
 
       root.style.setProperty("--viewport-height", `${stableHeight}px`);
+      // Expose keyboard + mobile padding metrics as CSS variables
+      // Consumers should apply padding via a class, not inline styles
+      root.style.setProperty("--keyboard-inset", `${keyboardHeight}px`);
+      const bottomMargin =
+        orientation === "portrait" ? Math.round(stableHeight * 0.075) : 0;
+      root.style.setProperty("--mobile-bottom-margin", `${bottomMargin}px`);
+      const pad = keyboardVisible
+        ? Math.max(0, keyboardHeight + bottomMargin)
+        : 0;
+      root.style.setProperty("--kb-pad", `${pad}px`);
 
       setViewportHeight(stableHeight);
       setViewportWidth(width);

--- a/src/hooks/useViewportMetrics.ts
+++ b/src/hooks/useViewportMetrics.ts
@@ -123,9 +123,7 @@ export const useViewportMetrics = () => {
       );
       orientationRef.current = orientation;
 
-      // Only reset baseline when keyboard is not visible.
-      // This preserves the last known full-height baseline across keyboard toggles.
-      if (reset && !keyboardVisible) {
+      if (reset || !keyboardVisible) {
         maxHeightRef.current[orientation] = 0;
       }
 
@@ -148,18 +146,6 @@ export const useViewportMetrics = () => {
         : 0;
 
       root.style.setProperty("--viewport-height", `${stableHeight}px`);
-      // Expose keyboard + mobile padding metrics as CSS variables
-      // Consumers should apply padding via a class, not inline styles
-      root.style.setProperty("--keyboard-inset", `${keyboardHeight}px`);
-      const bottomMargin =
-        orientation === "portrait" ? Math.round(stableHeight * 0.075) : 0;
-      root.style.setProperty("--mobile-bottom-margin", `${bottomMargin}px`);
-      // Keyboard padding should exclude existing bottom margin:
-      // we only need the portion of the keyboard that intrudes into the content area
-      const pad = keyboardVisible
-        ? Math.max(0, keyboardHeight - bottomMargin)
-        : 0;
-      root.style.setProperty("--kb-pad", `${pad}px`);
 
       setViewportHeight(stableHeight);
       setViewportWidth(width);
@@ -186,8 +172,7 @@ export const useViewportMetrics = () => {
       }
       keyboardVisibleRef.current = visible;
       setKeyboardVisible(visible);
-      // Do not reset baseline on keyboard visibility toggles
-      scheduleUpdate(false);
+      scheduleUpdate(true);
     };
 
     const handleFocusIn = (event: FocusEvent) => {

--- a/src/hooks/useViewportMetrics.ts
+++ b/src/hooks/useViewportMetrics.ts
@@ -123,8 +123,7 @@ export const useViewportMetrics = () => {
       );
       orientationRef.current = orientation;
 
-      // Only reset baseline on orientation reset events
-      if (reset) {
+      if (reset || !keyboardVisible) {
         maxHeightRef.current[orientation] = 0;
       }
 
@@ -141,21 +140,10 @@ export const useViewportMetrics = () => {
         maxHeightRef.current[orientation] = stableHeight;
       }
 
-      // Calculate delta between baseline and current viewport
-      const delta = Math.max(0, stableHeight - height);
-      // Infer visibility based on viewport shrink, to handle Android back gesture
-      try {
-        const KEYBOARD_DELTA_PX = 120; // tune if needed (100–180)
-        const active = document.activeElement as Element | null;
-        const inferredVisible = delta > KEYBOARD_DELTA_PX && isKeyboardElement(active);
-        if (inferredVisible !== keyboardVisibleRef.current) {
-          keyboardVisibleRef.current = inferredVisible;
-          setKeyboardVisible(inferredVisible);
-        }
-      } catch {}
-
-      // Keyboard height for consumers that need it
-      const keyboardHeight = keyboardVisibleRef.current ? delta : 0;
+      // Calculate keyboard height: difference between stable and current viewport
+      const keyboardHeight = keyboardVisible
+        ? Math.max(0, stableHeight - height)
+        : 0;
 
       root.style.setProperty("--viewport-height", `${stableHeight}px`);
 
@@ -184,8 +172,7 @@ export const useViewportMetrics = () => {
       }
       keyboardVisibleRef.current = visible;
       setKeyboardVisible(visible);
-      // Do not reset baseline on visibility toggles
-      scheduleUpdate(false);
+      scheduleUpdate(true);
     };
 
     const handleFocusIn = (event: FocusEvent) => {


### PR DESCRIPTION
## Summary
Fixes mobile keyboard UX by implementing device-agnostic dynamic padding that adapts to actual keyboard height rather than using fixed viewport-based values.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## Changes
- Added `keyboardHeightAtom` to track actual keyboard height dynamically
- Updated `useViewportMetrics` hook to calculate keyboard height from viewport changes
- Replaced fixed `pb-[40dvh]` and `pb-[60dvh]` with dynamic padding in chat and contact forms
- Refactored inline padding to use style prop for better keyboard height responsiveness
- Minor styling tweaks to TooltipButton padding and Face component formatting

## Testing
- Test on iOS devices with varying keyboard heights
- Test on Android devices with different keyboard apps
- Verify chat thread scrolls properly when keyboard appears
- Verify contact form remains accessible with keyboard open
- Confirm smooth transitions when keyboard shows/hides

## Files Changed
- `src/atoms/atomStore.ts` - Added keyboard height atom
- `src/hooks/useViewportMetrics.ts` - Dynamic keyboard height calculation
- `src/components/scene/chat/assistant-ui/thread.tsx` - Dynamic padding implementation
- `src/components/scene/contact/ContactForm.tsx` - Dynamic padding implementation
- `src/components/shared/Face.tsx` - Code formatting cleanup
- `src/components/shared/TooltipButton.tsx` - Minor padding adjustment
