### PR TITLE
fix(nav): temporarily hide blog button until blog is live

### DIFF
--- a/src/components/footer/Navigation.tsx
+++ b/src/components/footer/Navigation.tsx
@@ -1,6 +1,5 @@
 import { useAtomValue, useSetAtom } from "jotai";
 import {
-  CircleUserIcon,
   FileUserIcon,
   FolderGit2Icon,
   MailIcon,
@@ -71,6 +70,7 @@ export const Navigation = ({
           round={isMobile ? false : true}
           size={10}
         />
+        {/* Blog button hidden temporarily — re-enable when blog is live
         {isMobile && <Separator className="my-1" />}
         <TooltipButton
           tooltip={activeFace !== "blog"}
@@ -93,6 +93,7 @@ export const Navigation = ({
           size={10}
         />
         {isMobile && <Separator className="my-1" />}
+        */}
         <TooltipButton
           tooltip={activeFace !== "projects"}
           disabled={activeFace === "projects"}


### PR DESCRIPTION
## Summary
- Wraps the Blog nav button in a JSX comment so it's hidden from the UI without deleting any code
- Removes the now-unused `CircleUserIcon` import

## To re-enable
Remove the `{/* ... */}` comment wrapper in `Navigation.tsx`.