### PR TITLE
fix(mobile): switch projects layout to flex column and restrict pnpm native builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,9 @@
   "pnpm": {
     "overrides": {
       "jotai": "^2.15.0"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
   }
 }

--- a/src/components/scene/projects/Projects.tsx
+++ b/src/components/scene/projects/Projects.tsx
@@ -109,7 +109,7 @@ const Projects = () => {
       className="
       w-full h-full p-0 grid gap-4
       overflow-x-hidden overflow-y-hidden
-      grid-rows-3 grid-cols-1 grow-1
+      flex flex-col grow-1
       md:p-4 md:grid-rows-2 md:grid-cols-2 md:gap-4"
     >
       {projectsArray.map((project, index) => (


### PR DESCRIPTION
## Summary

Two fixes landed accidentally on main and are being moved to this branch for proper review.

## Changes

- Switch the mobile projects layout from CSS grid to flex column for correct stacking on small screens
- Add `onlyBuiltDependencies` to `package.json` to restrict pnpm native builds to esbuild only

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Files Changed

- `src/components/scene/projects/Projects.tsx` - layout class changed from grid to flex column
- `package.json` - added `pnpm.onlyBuiltDependencies` field

## Testing

- Verify projects face renders correctly on mobile viewports
- Verify `pnpm install` completes without unexpected native build warnings

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No breaking changes
- [x] Tests pass locally